### PR TITLE
Use androidx.* instead of android.support.* library

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,6 +3,9 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <compositeConfiguration>
+          <compositeBuild compositeDefinitionSource="SCRIPT" />
+        </compositeConfiguration>
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">
@@ -12,13 +15,8 @@
             <option value="$PROJECT_DIR$/library" />
           </set>
         </option>
-        <option name="myModules">
-          <set>
-            <option value="$PROJECT_DIR$" />
-            <option value="$PROJECT_DIR$/app" />
-            <option value="$PROJECT_DIR$/library" />
-          </set>
-        </option>
+        <option name="resolveModulePerSourceSet" value="false" />
+        <option name="testRunner" value="PLATFORM" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,28 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="EntryPointsManager">
-    <entry_points version="2.0" />
-  </component>
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
     <option name="myNullables">
       <value>
-        <list size="4">
+        <list size="12">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
           <item index="3" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
+          <item index="4" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
+          <item index="5" class="java.lang.String" itemvalue="androidx.annotation.Nullable" />
+          <item index="6" class="java.lang.String" itemvalue="android.annotation.Nullable" />
+          <item index="7" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNullable" />
+          <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
+          <item index="9" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
+          <item index="10" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
+          <item index="11" class="java.lang.String" itemvalue="com.android.annotations.Nullable" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="4">
+        <list size="11">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
           <item index="3" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
+          <item index="4" class="java.lang.String" itemvalue="androidx.annotation.NonNull" />
+          <item index="5" class="java.lang.String" itemvalue="android.annotation.NonNull" />
+          <item index="6" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNonNull" />
+          <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
+          <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
+          <item index="9" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
+          <item index="10" class="java.lang.String" itemvalue="com.android.annotations.NonNull" />
         </list>
       </value>
     </option>
@@ -46,17 +58,7 @@
       </profile-state>
     </entry>
   </component>
-  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
-    <OptionsSetting value="true" id="Add" />
-    <OptionsSetting value="true" id="Remove" />
-    <OptionsSetting value="true" id="Checkout" />
-    <OptionsSetting value="true" id="Update" />
-    <OptionsSetting value="true" id="Status" />
-    <OptionsSetting value="true" id="Edit" />
-    <ConfirmationsSetting value="0" id="Add" />
-    <ConfirmationsSetting value="0" id="Remove" />
-  </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
 }
 
 dependencies {
-    compile project(":library")
-    testCompile 'junit:junit:4.12'
-    compile rootProject.ext.appcompat
-    compile rootProject.ext.design
+    implementation project(":library")
+    testImplementation 'junit:junit:4.12'
+    implementation rootProject.ext.appcompat
+    implementation rootProject.ext.design
 }

--- a/app/src/main/java/com/github/techisfun/android/topsheet/app/MainActivity.java
+++ b/app/src/main/java/com/github/techisfun/android/topsheet/app/MainActivity.java
@@ -1,13 +1,14 @@
 package com.github.techisfun.android.topsheet.app;
 
-import android.support.design.widget.BottomSheetBehavior;
-import android.support.design.widget.BottomSheetDialog;
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.view.View;
 
+import androidx.appcompat.app.AppCompatActivity;
+
 import com.github.techisfun.android.topsheet.TopSheetBehavior;
 import com.github.techisfun.android.topsheet.TopSheetDialog;
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.google.android.material.bottomsheet.BottomSheetDialog;
 
 public class MainActivity extends AppCompatActivity {
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -87,4 +87,4 @@
 
     </FrameLayout>
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -15,6 +16,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }
@@ -25,16 +27,16 @@ task clean(type: Delete) {
 
 ext {
     minSdkVersion = 15
-    compileSdkVersion = 24
-    targetSdkVersion = 24
-    buildToolsVersion = "23.0.2"
+    compileSdkVersion = 29
+    targetSdkVersion = 29
+    buildToolsVersion = "29.0.0"
 
     // android
-    appcompat = 'com.android.support:appcompat-v7:24.1.1'
+    appcompat = 'androidx.appcompat:appcompat:1.1.0'
     //supportv4 = 'com.android.support:support-v4:24.1.1'
-    //supportannotations = 'com.android.support:support-annotations:24.1.1'
+    annotation = "androidx.annotation:annotation:1.1.0"
     //recyclerview = 'com.android.support:recyclerview-v7:24.1.1'
-    design = 'com.android.support:design:24.1.1'
+    design = 'com.google.android.material:material:1.0.0'
     //percent = 'com.android.support:percent:24.1.1'
 
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Aug 23 15:35:31 CEST 2016
+#Wed Dec 04 15:10:43 KST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -22,7 +22,8 @@ android {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    compile rootProject.ext.design
-    compile rootProject.ext.appcompat
+    testImplementation 'junit:junit:4.12'
+    implementation rootProject.ext.design
+    implementation rootProject.ext.appcompat
+    implementation rootProject.ext.annotation
 }

--- a/library/src/main/java/com/github/techisfun/android/topsheet/TopSheetBehavior.java
+++ b/library/src/main/java/com/github/techisfun/android/topsheet/TopSheetBehavior.java
@@ -55,53 +55,53 @@ import java.lang.ref.WeakReference;
 public class TopSheetBehavior<V extends View> extends CoordinatorLayout.Behavior<V> {
 
     /**
-     * Callback for monitoring events about bottom sheets.
+     * Callback for monitoring events about top sheets.
      */
     public abstract static class TopSheetCallback {
 
         /**
-         * Called when the bottom sheet changes its state.
+         * Called when the top sheet changes its state.
          *
-         * @param bottomSheet The bottom sheet view.
+         * @param topSheet The top sheet view.
          * @param newState    The new state. This will be one of {@link #STATE_DRAGGING},
          *                    {@link #STATE_SETTLING}, {@link #STATE_EXPANDED},
          *                    {@link #STATE_COLLAPSED}, or {@link #STATE_HIDDEN}.
          */
-        public abstract void onStateChanged(@NonNull View bottomSheet, @State int newState);
+        public abstract void onStateChanged(@NonNull View topSheet, @State int newState);
 
         /**
-         * Called when the bottom sheet is being dragged.
+         * Called when the top sheet is being dragged.
          *
-         * @param bottomSheet The bottom sheet view.
-         * @param slideOffset The new offset of this bottom sheet within its range, from 0 to 1
+         * @param topSheet The top sheet view.
+         * @param slideOffset The new offset of this top sheet within its range, from 0 to 1
          *                    when it is moving upward, and from 0 to -1 when it moving downward.
          * @param isOpening   detect showing
          */
-        public abstract void onSlide(@NonNull View bottomSheet, float slideOffset, @Nullable Boolean isOpening);
+        public abstract void onSlide(@NonNull View topSheet, float slideOffset, @Nullable Boolean isOpening);
     }
 
     /**
-     * The bottom sheet is dragging.
+     * The top sheet is dragging.
      */
     public static final int STATE_DRAGGING = 1;
 
     /**
-     * The bottom sheet is settling.
+     * The top sheet is settling.
      */
     public static final int STATE_SETTLING = 2;
 
     /**
-     * The bottom sheet is expanded.
+     * The top sheet is expanded.
      */
     public static final int STATE_EXPANDED = 3;
 
     /**
-     * The bottom sheet is collapsed.
+     * The top sheet is collapsed.
      */
     public static final int STATE_COLLAPSED = 4;
 
     /**
-     * The bottom sheet is hidden.
+     * The top sheet is hidden.
      */
     public static final int STATE_HIDDEN = 5;
 
@@ -207,7 +207,7 @@ public class TopSheetBehavior<V extends View> extends CoordinatorLayout.Behavior
         int savedTop = child.getTop();
         // First let the parent lay it out
         parent.onLayoutChild(child, layoutDirection);
-        // Offset the bottom sheet
+        // Offset the top sheet
         mParentHeight = parent.getHeight();
         mMinOffset = Math.max(-child.getHeight(), -(child.getHeight() - mPeekHeight));
         mMaxOffset = 0;
@@ -268,7 +268,7 @@ public class TopSheetBehavior<V extends View> extends CoordinatorLayout.Behavior
         if (!mIgnoreEvents && mViewDragHelper.shouldInterceptTouchEvent(event)) {
             return true;
         }
-        // We have to handle cases that the ViewDragHelper does not capture the bottom sheet because
+        // We have to handle cases that the ViewDragHelper does not capture the top sheet because
         // it is not the top most view of its parent. This is not necessary when the touch event is
         // happening over the scrolling content as nested scrolling logic handles that case.
         View scroll = mNestedScrollingChildRef.get();
@@ -299,7 +299,7 @@ public class TopSheetBehavior<V extends View> extends CoordinatorLayout.Behavior
             }
             mVelocityTracker.addMovement(event);
             // The ViewDragHelper tries to capture only the top-most View. We have to explicitly tell it
-            // to capture the bottom sheet in case it is not captured and the touch slop is passed.
+            // to capture the top sheet in case it is not captured and the touch slop is passed.
             if (action == MotionEvent.ACTION_MOVE && !mIgnoreEvents) {
                 if (Math.abs(mInitialY - event.getY()) > mViewDragHelper.getTouchSlop()) {
                     mViewDragHelper.captureChildView(child, event.getPointerId(event.getActionIndex()));
@@ -404,10 +404,10 @@ public class TopSheetBehavior<V extends View> extends CoordinatorLayout.Behavior
     }
 
     /**
-     * Sets the height of the bottom sheet when it is collapsed.
+     * Sets the height of the top sheet when it is collapsed.
      *
-     * @param peekHeight The height of the collapsed bottom sheet in pixels.
-     * @attr ref android.support.design.R.styleable#TopSheetBehavior_Params_behavior_peekHeight
+     * @param peekHeight The height of the collapsed top sheet in pixels.
+     * @attr ref com.google.android.material.R.styleable#TopSheetBehavior_Params_behavior_peekHeight
      */
     public final void setPeekHeight(int peekHeight) {
         mPeekHeight = Math.max(0, peekHeight);
@@ -418,68 +418,68 @@ public class TopSheetBehavior<V extends View> extends CoordinatorLayout.Behavior
     }
 
     /**
-     * Gets the height of the bottom sheet when it is collapsed.
+     * Gets the height of the top sheet when it is collapsed.
      *
-     * @return The height of the collapsed bottom sheet.
-     * @attr ref android.support.design.R.styleable#BottomSheetBehavior_Layout_behavior_peekHeight
+     * @return The height of the collapsed top sheet.
+     * @attr ref com.google.android.material.R.styleable#BottomSheetBehavior_Layout_behavior_peekHeight
      */
     public final int getPeekHeight() {
         return mPeekHeight;
     }
 
     /**
-     * Sets whether this bottom sheet can hide when it is swiped down.
+     * Sets whether this top sheet can hide when it is swiped down.
      *
-     * @param hideable {@code true} to make this bottom sheet hideable.
-     * @attr ref android.support.design.R.styleable#BottomSheetBehavior_Layout_behavior_hideable
+     * @param hideable {@code true} to make this top sheet hideable.
+     * @attr ref com.google.android.material.R.styleable#BottomSheetBehavior_Layout_behavior_hideable
      */
     public void setHideable(boolean hideable) {
         mHideable = hideable;
     }
 
     /**
-     * Gets whether this bottom sheet can hide when it is swiped down.
+     * Gets whether this top sheet can hide when it is swiped down.
      *
-     * @return {@code true} if this bottom sheet can hide.
-     * @attr ref android.support.design.R.styleable#BottomSheetBehavior_Layout_behavior_hideable
+     * @return {@code true} if this top sheet can hide.
+     * @attr ref com.google.android.material.R.styleable#BottomSheetBehavior_Layout_behavior_hideable
      */
     public boolean isHideable() {
         return mHideable;
     }
 
     /**
-     * Sets whether this bottom sheet should skip the collapsed state when it is being hidden
+     * Sets whether this top sheet should skip the collapsed state when it is being hidden
      * after it is expanded once. Setting this to true has no effect unless the sheet is hideable.
      *
-     * @param skipCollapsed True if the bottom sheet should skip the collapsed state.
-     * @attr ref android.support.design.R.styleable#BottomSheetBehavior_Layout_behavior_skipCollapsed
+     * @param skipCollapsed True if the top sheet should skip the collapsed state.
+     * @attr ref com.google.android.material.R.styleable#BottomSheetBehavior_Layout_behavior_skipCollapsed
      */
     public void setSkipCollapsed(boolean skipCollapsed) {
         mSkipCollapsed = skipCollapsed;
     }
 
     /**
-     * Sets whether this bottom sheet should skip the collapsed state when it is being hidden
+     * Sets whether this top sheet should skip the collapsed state when it is being hidden
      * after it is expanded once.
      *
-     * @return Whether the bottom sheet should skip the collapsed state.
-     * @attr ref android.support.design.R.styleable#BottomSheetBehavior_Layout_behavior_skipCollapsed
+     * @return Whether the top sheet should skip the collapsed state.
+     * @attr ref com.google.android.material.R.styleable#BottomSheetBehavior_Layout_behavior_skipCollapsed
      */
     public boolean getSkipCollapsed() {
         return mSkipCollapsed;
     }
 
     /**
-     * Sets a callback to be notified of bottom sheet events.
+     * Sets a callback to be notified of top sheet events.
      *
-     * @param callback The callback to notify when bottom sheet events occur.
+     * @param callback The callback to notify when top sheet events occur.
      */
     public void setTopSheetCallback(TopSheetCallback callback) {
         mCallback = callback;
     }
 
     /**
-     * Sets the state of the bottom sheet. The bottom sheet will transition to that state with
+     * Sets the state of the top sheet. The top sheet will transition to that state with
      * animation.
      *
      * @param state One of {@link #STATE_COLLAPSED}, {@link #STATE_EXPANDED}, or
@@ -518,7 +518,7 @@ public class TopSheetBehavior<V extends View> extends CoordinatorLayout.Behavior
     }
 
     /**
-     * Gets the current state of the bottom sheet.
+     * Gets the current state of the top sheet.
      *
      * @return One of {@link #STATE_EXPANDED}, {@link #STATE_COLLAPSED}, {@link #STATE_DRAGGING},
      * and {@link #STATE_SETTLING}.
@@ -539,9 +539,9 @@ public class TopSheetBehavior<V extends View> extends CoordinatorLayout.Behavior
             return;
         }
         mState = state;
-        View bottomSheet = mViewRef.get();
-        if (bottomSheet != null && mCallback != null) {
-            mCallback.onStateChanged(bottomSheet, state);
+        View topSheet = mViewRef.get();
+        if (topSheet != null && mCallback != null) {
+            mCallback.onStateChanged(topSheet, state);
         }
     }
 
@@ -668,15 +668,15 @@ public class TopSheetBehavior<V extends View> extends CoordinatorLayout.Behavior
     };
 
     private void dispatchOnSlide(int top) {
-        View bottomSheet = mViewRef.get();
-        if (bottomSheet != null && mCallback != null) {
+        View topSheet = mViewRef.get();
+        if (topSheet != null && mCallback != null) {
 
             Boolean isOpening = oldState == TopSheetBehavior.STATE_COLLAPSED;
 
             if (top < mMinOffset) {
-                mCallback.onSlide(bottomSheet, (float) (top - mMinOffset) / mPeekHeight, isOpening);
+                mCallback.onSlide(topSheet, (float) (top - mMinOffset) / mPeekHeight, isOpening);
             } else {
-                mCallback.onSlide(bottomSheet,
+                mCallback.onSlide(topSheet,
                         (float) (top - mMinOffset) / ((mMaxOffset - mMinOffset)), isOpening);
             }
         }

--- a/library/src/main/java/com/github/techisfun/android/topsheet/TopSheetDialog.java
+++ b/library/src/main/java/com/github/techisfun/android/topsheet/TopSheetDialog.java
@@ -18,17 +18,20 @@ package com.github.techisfun.android.topsheet;
 import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.annotation.LayoutRes;
-import android.support.annotation.NonNull;
-import android.support.annotation.StyleRes;
-import android.support.design.widget.BottomSheetBehavior;
-import android.support.design.widget.CoordinatorLayout;
-import android.support.v7.app.AppCompatDialog;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.widget.FrameLayout;
+
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StyleRes;
+import androidx.appcompat.app.AppCompatDialog;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
 
 /**
  * Created by andrea on 23/08/16.
@@ -134,7 +137,7 @@ public class TopSheetDialog extends AppCompatDialog {
             // If the provided theme is 0, then retrieve the dialogTheme from our theme
             TypedValue outValue = new TypedValue();
             if (context.getTheme().resolveAttribute(
-                    android.support.design.R.attr.bottomSheetDialogTheme, outValue, true)) {
+                    com.google.android.material.R.attr.bottomSheetDialogTheme, outValue, true)) {
                 themeId = outValue.resourceId;
             } else {
                 // bottomSheetDialogTheme is not provided; we default to our light theme
@@ -155,7 +158,8 @@ public class TopSheetDialog extends AppCompatDialog {
         }
 
         @Override
-        public void onSlide(@NonNull View topSheet, float slideOffset) {
+        public void onSlide(@NonNull View topSheet, float slideOffset, @Nullable Boolean isOpening) {
+
         }
     };
 

--- a/library/src/main/java/com/github/techisfun/android/topsheet/TopSheetDialogFragment.java
+++ b/library/src/main/java/com/github/techisfun/android/topsheet/TopSheetDialogFragment.java
@@ -2,7 +2,8 @@ package com.github.techisfun.android.topsheet;
 
 import android.app.Dialog;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatDialogFragment;
+
+import androidx.appcompat.app.AppCompatDialogFragment;
 
 /**
  * Created by andrea on 23/08/16.

--- a/library/src/main/res/layout/top_sheet_dialog.xml
+++ b/library/src/main/res/layout/top_sheet_dialog.xml
@@ -14,7 +14,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
 -->
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
@@ -38,4 +38,4 @@
         style="@style/Widget.Design.TopSheet.Modal"
         />
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
This PR contains changes that replace `android.support` library to `androidx` library.

Android support library is still available, but Google recommends to use AndroidX library instead of support library. Especially, they noted that all new library development will occur in the AndroidX library. (Check this [Link](https://developer.android.com/topic/libraries/support-library))

So I think it would be better to use AndroidX library instead of support library.

What I change includes: 

`androidx` libraries instead of `android.support` libraries.
- `appcompat = 'androidx.appcompat:appcompat:1.1.0'` instead of `appcompat = 'com.android.support:appcompat-v7:24.1.1'`
- `annotation = "androidx.annotation:annotation:1.1.0"`
- `design = 'com.google.android.material:material:1.0.0'` instead of `design = 'com.android.support:design:24.1.1'`

`compileSdkVersion`, `targetSdkVersion`, `buildToolsVersion`, and gradle version.
- `compileSdkVersion = 29` (previously `compileSdkVersion = 24`)
- `targetSdkVersion = 24` (previously `targetSdkVersion = 24`)
- `buildToolsVersion = "29.0.0"` (previously `buildToolsVersion = "23.0.2"`)
- `classpath 'com.android.tools.build:gradle:3.5.2'` (previously `classpath 'com.android.tools.build:gradle:2.1.3'`)

